### PR TITLE
Fix Stage 1 retry counter register

### DIFF
--- a/stage1.asm
+++ b/stage1.asm
@@ -39,7 +39,7 @@ start:
     mov cl, 2        ; Sektor 2
     mov dh, 0        ; Head 0
     mov dl, [boot_drive]
-    mov cx, 3        ; 3 Versuche
+    mov si, 3        ; 3 Versuche
 
 .retry:
     pusha
@@ -48,7 +48,7 @@ start:
     jnc .read_ok
 
     ; Reset und neu versuchen
-    dec cx
+    dec si
     jz error
     push ax
     xor ax, ax


### PR DESCRIPTION
## Summary
- move the Stage 1 retry counter from CX to SI so CH/CL keep the disk CHS
- adjust the retry loop to use the new counter while leaving CX intact for BIOS reads

## Testing
- not run (real hardware/QEMU not available in this environment)
