### PR TITLE
Add paging initialization with uncached VGA mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ main.o: main.c main.h config.h display.h
 memory.o: memory.c memory.h bootinfo.h console.h
 	$(CC) $(CFLAGS) $(CDEFS) -c $< -o $@
 
+paging.o: paging.c paging.h bootinfo.h config.h
+	$(CC) $(CFLAGS) $(CDEFS) -c $< -o $@
+
 video.o: video.c main.h config.h display.h
 	$(CC) $(CFLAGS) $(CDEFS) -c $< -o $@
 
@@ -209,7 +212,7 @@ cpu.o: cpu.c cpu.h console.h
 cpuidle.o: cpuidle.c cpuidle.h config.h
 	$(CC) $(CFLAGS) $(CDEFS) -c $< -o $@
 
-kernel_payload.elf: entry32.o kentry.o isr.o idt.o interrupts.o platform.o main.o memory.o video.o console.o debug_serial.o statusbar.o display.o fonts/font8x16.o $(CONSOLE_BACKEND_OBJ) netface.o net/ipv4.o net/tcp_min.o mezapi.o apps/keymusic_app.o apps/rotcube_app.o apps/fbtest_color.o apps/gpu_probe.o drivers/ne2000.o drivers/pcspeaker.o drivers/sb16.o drivers/pci.o drivers/gpu/gpu.o drivers/gpu/cirrus.o drivers/gpu/cirrus_accel.o drivers/gpu/et4000.o drivers/gpu/et4000ax.o drivers/gpu/fb_accel.o drivers/gpu/vga_hw.o drivers/ata.o drivers/fs/neelefs.o drivers/storage.o keyboard.o cpu.o cpuidle.o shell.o
+kernel_payload.elf: entry32.o kentry.o isr.o idt.o interrupts.o platform.o main.o memory.o paging.o video.o console.o debug_serial.o statusbar.o display.o fonts/font8x16.o $(CONSOLE_BACKEND_OBJ) netface.o net/ipv4.o net/tcp_min.o mezapi.o apps/keymusic_app.o apps/rotcube_app.o apps/fbtest_color.o apps/gpu_probe.o drivers/ne2000.o drivers/pcspeaker.o drivers/sb16.o drivers/pci.o drivers/gpu/gpu.o drivers/gpu/cirrus.o drivers/gpu/cirrus_accel.o drivers/gpu/et4000.o drivers/gpu/et4000ax.o drivers/gpu/fb_accel.o drivers/gpu/vga_hw.o drivers/ata.o drivers/fs/neelefs.o drivers/storage.o keyboard.o cpu.o cpuidle.o shell.o
 	$(LD) $(LDFLAGS) $^ -o $@
 
 # Erzeuge flaches Binary ohne führende 0x8000-Lücke
@@ -304,7 +307,7 @@ help:
 
 clean:
 	# Root objs and binaries
-	rm -f *.o *.bin *.img netface.o console.o $(CONSOLE_BACKEND_OBJ) video.o main.o entry32.o isr.o idt.o interrupts.o kentry.o kernel_payload.bin kernel_payload.elf stage3.elf
+	rm -f *.o *.bin *.img netface.o console.o $(CONSOLE_BACKEND_OBJ) video.o main.o entry32.o isr.o idt.o interrupts.o kentry.o paging.o kernel_payload.bin kernel_payload.elf stage3.elf
 	# Driver objects
 	rm -f drivers/*.o drivers/*/*.o
 	# SPARC artifacts

--- a/kentry.c
+++ b/kentry.c
@@ -1,6 +1,7 @@
 #include "bootinfo.h"
 #include "config.h"
 #include <stddef.h>
+#include "paging.h"
 
 #if CONFIG_ARCH_X86
 // Legacy kernel main (no bootinfo)
@@ -64,6 +65,7 @@ void kentry(void* bi) {
         static boot_info_t fallback;
         info = &fallback;
     }
+    paging_init(info);
     kmain(info);
 #elif CONFIG_ARCH_SPARC
     boot_info_t* info = (boot_info_t*)bi;

--- a/paging.c
+++ b/paging.c
@@ -1,0 +1,137 @@
+#include "paging.h"
+#include "config.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if CONFIG_ARCH_X86
+#define PAGE_PRESENT 0x001u
+#define PAGE_RW      0x002u
+#define PAGE_PWT     0x008u
+#define PAGE_PCD     0x010u
+
+#define PAGING_MAX_TABLES 64u
+
+static uint32_t g_page_directory[1024] __attribute__((aligned(4096)));
+static uint32_t g_page_tables[PAGING_MAX_TABLES][1024] __attribute__((aligned(4096)));
+static int g_paging_enabled = 0;
+
+static inline uint32_t align_up(uint32_t value, uint32_t alignment) {
+    return (value + alignment - 1u) & ~(alignment - 1u);
+}
+
+static uint32_t detect_highest_physical(const boot_info_t* info) {
+    uint64_t highest = 0x01000000ull; // default: map at least 16 MiB
+    extern uint8_t _end;
+    uint32_t kernel_end = align_up((uint32_t)(uintptr_t)&_end, 0x1000u);
+    if ((uint64_t)kernel_end > highest) {
+        highest = (uint64_t)kernel_end;
+    }
+
+    if (info) {
+        const bootinfo_memory_map_t* map = &info->memory;
+        uint32_t count = map->entry_count;
+        if (count > BOOTINFO_MEMORY_MAX_RANGES) {
+            count = BOOTINFO_MEMORY_MAX_RANGES;
+        }
+        for (uint32_t i = 0; i < count; ++i) {
+            const bootinfo_memory_range_t* r = &map->entries[i];
+            if (r->length == 0) {
+                continue;
+            }
+            uint64_t end = r->base + r->length;
+            if (end > highest) {
+                highest = end;
+            }
+        }
+    }
+
+    uint64_t max_cover = (uint64_t)PAGING_MAX_TABLES * 1024u * 4096u;
+    if (highest > max_cover) {
+        highest = max_cover;
+    }
+
+    if (highest < 0x00100000ull) {
+        highest = 0x00100000ull;
+    }
+
+    return (uint32_t)align_up((uint32_t)highest, 0x1000u);
+}
+
+static void build_identity_map(uint32_t limit_bytes) {
+    const uint32_t common_flags = PAGE_PRESENT | PAGE_RW;
+    const uint32_t uncached_flags = common_flags | PAGE_PWT | PAGE_PCD;
+
+    for (size_t i = 0; i < 1024; ++i) {
+        g_page_directory[i] = 0u;
+    }
+
+    uint32_t total_pages = limit_bytes >> 12; // already aligned up
+    uint32_t tables_needed = (total_pages + 1023u) / 1024u;
+    if (tables_needed == 0) {
+        tables_needed = 1;
+    }
+    if (tables_needed > PAGING_MAX_TABLES) {
+        tables_needed = PAGING_MAX_TABLES;
+    }
+
+    for (uint32_t table = 0; table < tables_needed; ++table) {
+        uint32_t* pt = g_page_tables[table];
+        for (uint32_t entry = 0; entry < 1024u; ++entry) {
+            uint32_t phys = ((table * 1024u) + entry) * 4096u;
+            uint32_t flags = common_flags;
+            if (phys >= 0x000A0000u && phys <= 0x000BFFFFu) {
+                flags = uncached_flags;
+            }
+            pt[entry] = phys | flags;
+        }
+        g_page_directory[table] = (uint32_t)(uintptr_t)pt | common_flags;
+    }
+
+    for (uint32_t table = tables_needed; table < PAGING_MAX_TABLES; ++table) {
+        uint32_t* pt = g_page_tables[table];
+        for (uint32_t entry = 0; entry < 1024u; ++entry) {
+            pt[entry] = 0u;
+        }
+    }
+}
+
+void paging_init(const boot_info_t* info) {
+    if (g_paging_enabled) {
+        return;
+    }
+
+    uint32_t highest = detect_highest_physical(info);
+    build_identity_map(highest);
+
+    uint32_t cr3 = (uint32_t)(uintptr_t)g_page_directory;
+    __asm__ volatile ("mov %0, %%cr3" :: "r"(cr3) : "memory");
+
+    uint32_t cr0;
+    __asm__ volatile ("mov %%cr0, %0" : "=r"(cr0));
+    cr0 |= 0x80000000u; // CR0.PG
+    __asm__ volatile ("mov %0, %%cr0" :: "r"(cr0) : "memory");
+    __asm__ volatile ("mov %0, %%cr3" :: "r"(cr3) : "memory");
+
+    g_paging_enabled = 1;
+}
+
+int paging_is_enabled(void) {
+    if (g_paging_enabled) {
+        return 1;
+    }
+    uint32_t cr0;
+    __asm__ volatile ("mov %%cr0, %0" : "=r"(cr0));
+    return (cr0 & 0x80000000u) ? 1 : 0;
+}
+
+#else
+
+void paging_init(const boot_info_t* info) {
+    (void)info;
+}
+
+int paging_is_enabled(void) {
+    return 0;
+}
+
+#endif

--- a/paging.h
+++ b/paging.h
@@ -1,0 +1,18 @@
+#ifndef PAGING_H
+#define PAGING_H
+
+#include <stdint.h>
+#include "bootinfo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void paging_init(const boot_info_t* info);
+int paging_is_enabled(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PAGING_H


### PR DESCRIPTION
## Summary
- add a paging module that builds identity-mapped page tables with PWT/PCD for the VGA window
- invoke the paging setup from the kernel entry point and hook the new module into the build

## Testing
- make kernel_payload.elf *(fails: /usr/include/string.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68f3647ee3308321aad72da5e5fb15b1