### PR TITLE
Guard ET4000 register programming with interrupt state

### DIFF
--- a/interrupts.c
+++ b/interrupts.c
@@ -47,8 +47,20 @@ void pit_init(uint32_t hz) {
     outb(0x40, (uint8_t)((div >> 8) & 0xFF));
 }
 
-void interrupts_enable(void){ __asm__ volatile("sti"); }
-void interrupts_disable(void){ __asm__ volatile("cli"); }
+void interrupts_enable(void){ __asm__ volatile("sti" ::: "memory"); }
+void interrupts_disable(void){ __asm__ volatile("cli" ::: "memory"); }
+
+uint32_t interrupts_save_disable(void) {
+    uint32_t flags;
+    __asm__ volatile ("pushfl\n\tcli\n\tpopl %0" : "=r"(flags) : : "memory");
+    return flags;
+}
+
+void interrupts_restore(uint32_t flags) {
+    if (flags & (1u << 9)) {
+        interrupts_enable();
+    }
+}
 
 // C handler for IRQ0 (timer)
 // For IRQ1 keyboard

--- a/interrupts.h
+++ b/interrupts.h
@@ -9,6 +9,8 @@ void pic_mask_all(void);
 void pit_init(uint32_t hz);
 void interrupts_enable(void);
 void interrupts_disable(void);
+uint32_t interrupts_save_disable(void);
+void interrupts_restore(uint32_t flags);
 
 // Tick counter from PIT IRQ0
 uint32_t ticks_get(void);


### PR DESCRIPTION
## Summary
- add interrupt guard helpers for the ET4000 driver so register programming saves and restores the IF state
- expose reusable interrupt save/restore helpers in the interrupt subsystem
- tighten the interrupt save/disable helper so CLI happens atomically with flag capture and add memory barriers around CLI/STI

## Testing
- make -s *(fails: `/usr/include/string.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68f36762f7ec8321b57c53f9402fdb7e