### PR TITLE
Reset ET4000 plane mask after sync

### DIFF
--- a/drivers/gpu/et4000.c
+++ b/drivers/gpu/et4000.c
@@ -423,6 +423,11 @@ static void et4k_shadow_upload(const et4k_fb_state_t* state) {
     }
 
     et4k_seq_write(0x02, 0x0F);
+    et4k_gc_write(0x08, 0xFF);
+    if (et4k_trace_enabled()) {
+        et4k_log_reg_write("SEQ_PLANE", 0x02, 0x0F);
+        et4k_log_reg_write("GC_BITMASK", 0x08, 0xFF);
+    }
     et4k_log("shadow_upload: end");
 
     et4k_irq_guard_release(irq_flags);


### PR DESCRIPTION
## Summary
- ensure the ET4000 shadow upload restores the sequencer plane mask and graphics controller bitmask
- add debug logging of the restored register values when tracing is enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3c381d3388321ba284ed39f882753